### PR TITLE
fix: responsive style when screen width 1440<x<1920

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -425,3 +425,14 @@ html {
 .vp-doc h4 {
   scroll-margin-top: calc(var(--vp-nav-height) + 20px);
 }
+
+.VPSidebar {
+  min-width: var(--vp-sidebar-width);
+}
+
+@media (min-width: 1440px) and (max-width: 1920px) {
+  .VPContent.has-sidebar,
+  .VPNavBar.has-sidebar .content {
+    padding-left: var(--vp-sidebar-width) !important;
+  }
+}


### PR DESCRIPTION
# Bug Fix PR

## Bug Summary
Docs layout on 1440‑1920px screens showed the sidebar collapsing below its intended width, so content jumped underneath it and the navbar content misaligned. Readers saw overlapping text and inconsistent left padding.

## Root Cause

Many styling calculations depend on the `—vp-layout-max-width` CSS variable. The default value is 1440 pixels, but we override it to 1920 pixels. This change causes the overall layout to break.

## Fix

reset the styling to value that used before hitting default `—vp-layout-max-width`(1440px)'s value
<img width="829" height="542" alt="image" src="https://github.com/user-attachments/assets/84340b40-ead0-453e-872f-ed3f8e7fb795" />


## Repro & Verification Steps

Check the web on screen width between 1440px and 1920px

## Risk & Rollback Plan

-

## Checklist

- [x] Linked issue/bug report
- [x] Previously failing tests now pass / new tests added
- [x] Lint & build pass
- [x] No API changes without notes
- [x] Changelog updated if needed
