### PR TITLE
fix: reordered getWebOutputPaths resolution

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -99,13 +99,13 @@ export class PathConfig {
     const paths = [
       join('/app', this.LENSCORE_DIR_NAME, this.WEB_DIR, this.OUTPUT_DIR),
       join('/app', this.WEB_DIR, this.OUTPUT_DIR),
-      join(this.getLenscoreHomeDir(), this.WEB_DIR, this.OUTPUT_DIR),
       join(
         this.getLenscoreProjectDir(process.cwd()),
         this.WEB_DIR,
         this.OUTPUT_DIR
       ),
       join(process.cwd(), this.WEB_DIR, this.OUTPUT_DIR),
+      join(this.getLenscoreHomeDir(), this.WEB_DIR, this.OUTPUT_DIR),
     ];
 
     const packagePath = resolvePackage('@accesstime/lenscore');


### PR DESCRIPTION
# Bug Fix PR
https://github.com/Access-Time/LensCore/issues/35

## Bug Summary

In my home directory i have .lenscore, therefore the results got stored in there, but the web resutls server serves results from the app repository i was running it


## Root Cause

Summarize the underlying cause identified.

## Fix

Describe the approach taken and alternatives considered.

## Repro & Verification Steps

Steps to reproduce the bug and verify the fix.

## Risk & Rollback Plan

Potential side effects and the rollback plan.

## Checklist

- [x] Linked issue/bug report
- [ ] Previously failing tests now pass / new tests added
- [ ] Lint & build pass
- [x] No API changes without notes
- [x] Changelog updated if needed
